### PR TITLE
Remove tabs and newlines in time

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -193,6 +193,7 @@ readTCX <- function(file, timezone = "", speedunit = "m_per_s", distanceunit = "
     ## END hack
 
     ## coerce time into POSIXct
+    newdat$time <- gsub("[\t\n]", "", newdat$time)
     newdat$time <- convertTCXTimes2POSIXct(newdat$time, timezone = timezone)
     ## newdat$time <- as.POSIXct(newdat$time, format = "%Y-%m-%dT%H:%M:%OSZ",
     ##                           tz = timezone)


### PR DESCRIPTION
Tabs and newlines stop the proper parsing of the time string to a POSIXct.
This is a follow-up to issue #1.
